### PR TITLE
Support P2F and F2P Convertors with multiple field arguments.

### DIFF
--- a/test_generator/F2PConvertor.cpp
+++ b/test_generator/F2PConvertor.cpp
@@ -1,12 +1,23 @@
 #include "json.hpp"
 #include "universal/include/universal/posit/posit.hpp"
 #include <algorithm>
+#include <cstdlib>
 #include <fstream>
+#include <getopt.h>
 #include <iostream>
 #include <map>
 #include <string>
+#include <unistd.h>
+#include <vector>
 
 using json_t = nlohmann::json;
+
+struct Input {
+    json_t json;
+    int posit_width;
+    std::vector<std::string> one_dim_fields;
+    std::vector<std::string> two_dim_fields;
+};
 
 template <class T> struct tag { using type = T; };
 template <class Tag> using type = typename Tag::type;
@@ -14,18 +25,6 @@ template <class T, size_t n>
 struct n_dim_vec : tag<std::vector<type<n_dim_vec<T, n - 1>>>> {};
 template <class T> struct n_dim_vec<T, 0> : tag<T> {};
 template <class T, size_t n> using n_dim_vec_t = type<n_dim_vec<T, n>>;
-
-json_t parse_data(std::string file_path) {
-    std::ifstream file(file_path);
-    json_t j;
-    try {
-        file >> j;
-    } catch (nlohmann::detail::parse_error err) {
-        std::cerr << err.what() << std::endl;
-        exit(2);
-    }
-    return j;
-}
 
 template <size_t nbits, size_t es>
 void convert_float_to_posit(std::vector<double> &input,
@@ -38,10 +37,9 @@ void convert_float_to_posit(std::vector<double> &input,
 }
 
 template <size_t nbits, size_t es>
-void convert_path(json_t json, std::string field, int dim) {
+void convert_path(json_t json, std::string field, int dim,
+                  json_t &transformed) {
     try {
-        json_t transformed;
-        transformed = json;
         switch (dim) {
         case 1: {
             auto data = json[field]["data"].get<n_dim_vec_t<double, 1>>();
@@ -62,7 +60,6 @@ void convert_path(json_t json, std::string field, int dim) {
             std::cerr << "[Error] The value of the dimension should be 1 or 2"
                       << std::endl;
         }
-        std::cout << transformed.dump(2);
     } catch (nlohmann::json::type_error err) {
         std::cerr << "[Error] Expected `" << field
                   << ".data' field with type float[]" << std::endl;
@@ -70,39 +67,108 @@ void convert_path(json_t json, std::string field, int dim) {
     }
 }
 
-void convert_to_posit(json_t json, std::string field, int posit_width,
-                      int dim) {
+void convert_to_posit(json_t json, std::string field, int posit_width, int dim,
+                      json_t &transformed) {
     switch (posit_width) {
+    case 8:
+        convert_path<8, 1>(json, field, dim, transformed);
     case 16:
-        convert_path<16, 1>(json, field, dim);
+        convert_path<16, 1>(json, field, dim, transformed);
         break;
     case 32:
-        convert_path<32, 2>(json, field, dim);
+        convert_path<32, 2>(json, field, dim, transformed);
         break;
     case 64:
-        convert_path<64, 3>(json, field, dim);
+        convert_path<64, 3>(json, field, dim, transformed);
         break;
     case 128:
-        convert_path<128, 4>(json, field, dim);
+        convert_path<128, 4>(json, field, dim, transformed);
         break;
 
     default:
         std::cerr << "[Error] The supported posit standards are 16, 32 and 64"
                   << std::endl;
+        exit(2);
+    }
+}
+
+void split_strings(std::string input, char delimiter,
+                   std::vector<std::string> &fields) {
+    std::stringstream stream(input);
+    std::string field;
+
+    while (!stream.eof()) {
+        std::getline(stream, field, delimiter);
+        fields.push_back(field);
+    }
+}
+
+void parse_data(int argc, char **argv, Input &input) {
+    std::ifstream file(argv[1]);
+    try {
+        file >> input.json;
+    } catch (nlohmann::detail::parse_error err) {
+        std::cerr << err.what() << std::endl;
+        exit(2);
+    }
+
+    input.posit_width = std::stoi(argv[2]);
+
+    int c;
+    int index;
+    char *cvalue = NULL;
+    while (1) {
+        static struct option long_options[] = {
+            {"1d", required_argument, 0, 'o'},
+            {"2d", required_argument, 0, 't'},
+            {"help", no_argument, 0, 'h'},
+            {0, 0, 0, 0}};
+        int option_index = 0;
+        c = getopt_long(argc, argv, "o:t:h", long_options, &option_index);
+
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'o':
+            split_strings(optarg, ',', input.one_dim_fields);
+            break;
+        case 't':
+            split_strings(optarg, ',', input.two_dim_fields);
+            break;
+        case '?':
+            std::cerr << "Invalid option" << std::endl;
+            exit(2);
+        default:
+            abort();
+        }
+    }
+    if ((optind != argc - 2)) {
+        std::cerr << "Invalid ARGV-elements" << std::endl;
+        exit(2);
     }
 }
 
 int main(int argc, char *argv[]) {
-    if (argc != 5) {
+    if (!(argc >= 5)) {
         std::cerr << "Usage: " << argv[0]
-                  << "<json> <field> <dimension> <posit-width>\n"
+                  << "<json> <posit-width> --1d <one-dim field_1>,<one-dim "
+                     "field_2> --2d <two-dim field_1>,<two-dim field_2>\n"
                      "Converts a JSON file with floating points to posits \n";
         return 2;
     }
-    auto json_file = parse_data(argv[1]);
-    std::string field = argv[2];
-    int dim = std::atoi(argv[3]);
-    int width = std::atoi(argv[4]);
+    Input input;
+    parse_data(argc, argv, input);
+    json_t transformed = input.json;
 
-    convert_to_posit(json_file, field, width, dim);
+    for (int i = 0; i < input.one_dim_fields.size(); i++) {
+        convert_to_posit(input.json, input.one_dim_fields[i], input.posit_width,
+                         1, transformed);
+    }
+
+    for (int i = 0; i < input.two_dim_fields.size(); i++) {
+        convert_to_posit(input.json, input.two_dim_fields[i], input.posit_width,
+                         2, transformed);
+    }
+    std::cout << transformed.dump(2);
 }

--- a/test_generator/F2PConvertor.cpp
+++ b/test_generator/F2PConvertor.cpp
@@ -12,12 +12,17 @@
 
 using json_t = nlohmann::json;
 
-struct Input {
+struct Args {
     json_t json;
     int posit_width;
     std::vector<std::string> one_dim_fields;
     std::vector<std::string> two_dim_fields;
+    Args() = delete;
 };
+
+const static struct option long_options[] = {{"1d", required_argument, 0, 'o'},
+                                             {"2d", required_argument, 0, 't'},
+                                             {0, 0, 0, 0}};
 
 template <class T> struct tag { using type = T; };
 template <class Tag> using type = typename Tag::type;
@@ -26,11 +31,18 @@ struct n_dim_vec : tag<std::vector<type<n_dim_vec<T, n - 1>>>> {};
 template <class T> struct n_dim_vec<T, 0> : tag<T> {};
 template <class T, size_t n> using n_dim_vec_t = type<n_dim_vec<T, n>>;
 
+void print_usage(std::string command) {
+    std::cerr << "Usage: \n\t" << command
+              << " <json> <posit-width> --1d <one-dim field_1>,<one-dim "
+                 "field_2> --2d <two-dim field_1>,<two-dim field_2>\n\t"
+                 "Converts a JSON file with floating points to posits \n";
+}
+
 template <size_t nbits, size_t es>
 void convert_float_to_posit(std::vector<double> &input,
                             std::vector<unsigned long> &output) {
     std::transform(input.cbegin(), input.cend(), output.begin(),
-                   [](float v) -> unsigned long {
+                   [](double v) -> unsigned long {
                        sw::unum::posit<nbits, es> p(v);
                        return p.get().to_ulong();
                    });
@@ -81,19 +93,22 @@ void convert_to_posit(json_t json, std::string field, int posit_width, int dim,
     case 64:
         convert_path<64, 3>(json, field, dim, transformed);
         break;
-    case 128:
-        convert_path<128, 4>(json, field, dim, transformed);
-        break;
+        // TODO: Currently 128 bit is not supported as we are using unsigned
+        // long. case 128:
+        //     convert_path<128, 4>(json, field, dim, transformed);
+        //     break;
 
     default:
-        std::cerr << "[Error] The supported posit standards are 16, 32 and 64"
-                  << std::endl;
+        std::cerr
+            << "[Error] The supported posit standards are 8, 16, 32 and 64"
+            << std::endl;
         exit(2);
     }
 }
 
-void split_strings(std::string input, char delimiter,
-                   std::vector<std::string> &fields) {
+std::vector<std::string> split_strings(const std::string &input,
+                                       char delimiter) {
+    std::vector<std::string> fields;
     std::stringstream stream(input);
     std::string field;
 
@@ -101,64 +116,59 @@ void split_strings(std::string input, char delimiter,
         std::getline(stream, field, delimiter);
         fields.push_back(field);
     }
+    return fields;
 }
 
-void parse_data(int argc, char **argv, Input &input) {
+Args parse_data(int argc, char **argv) {
+    json_t json;
     std::ifstream file(argv[1]);
     try {
-        file >> input.json;
+        file >> json;
     } catch (nlohmann::detail::parse_error err) {
         std::cerr << err.what() << std::endl;
         exit(2);
     }
 
-    input.posit_width = std::stoi(argv[2]);
+    int posit_width = std::stoi(argv[2]);
 
-    int c;
-    int index;
-    char *cvalue = NULL;
-    while (1) {
-        static struct option long_options[] = {
-            {"1d", required_argument, 0, 'o'},
-            {"2d", required_argument, 0, 't'},
-            {"help", no_argument, 0, 'h'},
-            {0, 0, 0, 0}};
-        int option_index = 0;
-        c = getopt_long(argc, argv, "o:t:h", long_options, &option_index);
-
-        if (c == -1)
-            break;
-
+    int c, option_index;
+    std::vector<std::string> one_dim_fields, two_dim_fields, split;
+    while ((c = getopt_long(argc, argv, ":o:t:", long_options,
+                            &option_index)) != 1) {
         switch (c) {
         case 'o':
-            split_strings(optarg, ',', input.one_dim_fields);
+            split = split_strings(optarg, ',');
+            one_dim_fields.insert(one_dim_fields.end(), split.begin(),
+                                  split.end());
             break;
         case 't':
-            split_strings(optarg, ',', input.two_dim_fields);
+            split = split_strings(optarg, ',');
+            two_dim_fields.insert(two_dim_fields.end(), split.begin(),
+                                  split.end());
             break;
         case '?':
             std::cerr << "Invalid option" << std::endl;
+            print_usage(argv[0]);
             exit(2);
         default:
-            abort();
+            std::cerr << "Unexpected behaviour" << std::endl;
+            print_usage(argv[0]);
+            exit(2);
         }
     }
     if ((optind != argc - 2)) {
-        std::cerr << "Invalid ARGV-elements" << std::endl;
+        std::cerr << "Invalid arguments" << std::endl;
         exit(2);
     }
+    return Args{json, posit_width, one_dim_fields, two_dim_fields};
 }
 
 int main(int argc, char *argv[]) {
     if (!(argc >= 5)) {
-        std::cerr << "Usage: " << argv[0]
-                  << "<json> <posit-width> --1d <one-dim field_1>,<one-dim "
-                     "field_2> --2d <two-dim field_1>,<two-dim field_2>\n"
-                     "Converts a JSON file with floating points to posits \n";
+        print_usage(argv[0]);
         return 2;
     }
-    Input input;
-    parse_data(argc, argv, input);
+    Args input = parse_data(argc, argv);
     json_t transformed = input.json;
 
     for (int i = 0; i < input.one_dim_fields.size(); i++) {

--- a/test_generator/P2FConvertor.cpp
+++ b/test_generator/P2FConvertor.cpp
@@ -2,21 +2,26 @@
 #include "universal/include/universal/posit/posit.hpp"
 #include <algorithm>
 #include <fstream>
+#include <getopt.h>
 #include <iostream>
 #include <map>
 #include <string>
 #include <unistd.h>
-#include <getopt.h>
 #include <vector>
 
 using json_t = nlohmann::json;
 
-struct Input {
+struct Args {
     json_t json;
     int posit_width;
     std::vector<std::string> one_dim_fields;
     std::vector<std::string> two_dim_fields;
+    Args() = delete;
 };
+
+const static struct option long_options[] = {{"1d", required_argument, 0, 'o'},
+                                             {"2d", required_argument, 0, 't'},
+                                             {0, 0, 0, 0}};
 
 template <class T> struct tag { using type = T; };
 template <class Tag> using type = typename Tag::type;
@@ -24,6 +29,13 @@ template <class T, size_t n>
 struct n_dim_vec : tag<std::vector<type<n_dim_vec<T, n - 1>>>> {};
 template <class T> struct n_dim_vec<T, 0> : tag<T> {};
 template <class T, size_t n> using n_dim_vec_t = type<n_dim_vec<T, n>>;
+
+void print_usage(std::string command) {
+    std::cerr << "Usage: \n\t" << command
+              << " <json> <posit-width> --1d <one-dim field_1>,<one-dim "
+                 "field_2> --2d <two-dim field_1>,<two-dim field_2>\n\t"
+                 "Converts a JSON file with posits to floating floats \n";
+}
 
 template <size_t nbits, size_t es>
 void convert_posit_to_float(std::vector<unsigned long> &input,
@@ -37,7 +49,8 @@ void convert_posit_to_float(std::vector<unsigned long> &input,
 }
 
 template <size_t nbits, size_t es>
-void convert_path(json_t json, std::string field, int dim, json_t &transformed) {
+void convert_path(json_t json, std::string field, int dim,
+                  json_t &transformed) {
     try {
         switch (dim) {
         case 1: {
@@ -68,8 +81,8 @@ void convert_path(json_t json, std::string field, int dim, json_t &transformed) 
     }
 }
 
-void convert_to_float(json_t json, std::string field, int posit_width,
-                      int dim, json_t &transformed) {
+void convert_to_float(json_t json, std::string field, int posit_width, int dim,
+                      json_t &transformed) {
     switch (posit_width) {
     case 8:
         convert_path<8, 1>(json, field, dim, transformed);
@@ -83,18 +96,21 @@ void convert_to_float(json_t json, std::string field, int posit_width,
     case 64:
         convert_path<64, 3>(json, field, dim, transformed);
         break;
-    case 128:
-        convert_path<128, 4>(json, field, dim, transformed);
-        break;
+    // TODO: Currently 128 bit is not supported as we are using unsigned long.
+    // case 128:
+    //     convert_path<128, 4>(json, field, dim, transformed);
+    //     break;
     default:
-        std::cerr << "[Error] The supported posit standards are 16, 32 and 64"
-                  << std::endl;
-                  exit(2);
+        std::cerr
+            << "[Error] The supported posit standards are 8, 16, 32 and 64"
+            << std::endl;
+        exit(2);
     }
 }
 
-void split_strings(std::string input, char delimiter,
-                   std::vector<std::string> &fields) {
+std::vector<std::string> split_strings(const std::string &input,
+                                       char delimiter) {
+    std::vector<std::string> fields;
     std::stringstream stream(input);
     std::string field;
 
@@ -102,64 +118,59 @@ void split_strings(std::string input, char delimiter,
         std::getline(stream, field, delimiter);
         fields.push_back(field);
     }
+    return fields;
 }
 
-void parse_data(int argc, char **argv, Input &input) {
+Args parse_data(int argc, char **argv) {
+    json_t json;
     std::ifstream file(argv[1]);
     try {
-        file >> input.json;
+        file >> json;
     } catch (nlohmann::detail::parse_error err) {
         std::cerr << err.what() << std::endl;
         exit(2);
     }
 
-    input.posit_width = std::stoi(argv[2]);
+    int posit_width = std::stoi(argv[2]);
 
-    int c;
-    int index;
-    char *cvalue = NULL;
-    while (1) {
-        static struct option long_options[] = {
-            {"1d", required_argument, 0, 'o'},
-            {"2d", required_argument, 0, 't'},
-            {"help", no_argument, 0, 'h'},
-            {0, 0, 0, 0}};
-        int option_index = 0;
-        c = getopt_long(argc, argv, "o:t:h", long_options, &option_index);
-
-        if (c == -1)
-            break;
-
+    int c, option_index;
+    std::vector<std::string> one_dim_fields, two_dim_fields, split;
+    while ((c = getopt_long(argc, argv, ":o:t:", long_options,
+                            &option_index)) != -1) {
         switch (c) {
         case 'o':
-            split_strings(optarg, ',', input.one_dim_fields);
+            split = split_strings(optarg, ',');
+            one_dim_fields.insert(one_dim_fields.end(), split.begin(),
+                                  split.end());
             break;
         case 't':
-            split_strings(optarg, ',', input.two_dim_fields);
+            split = split_strings(optarg, ',');
+            two_dim_fields.insert(two_dim_fields.end(), split.begin(),
+                                  split.end());
             break;
         case '?':
             std::cerr << "Invalid option" << std::endl;
+            print_usage(argv[0]);
             exit(2);
         default:
-            abort();
+            std::cerr << "Unexpected behaviour" << std::endl;
+            print_usage(argv[0]);
+            exit(2);
         }
     }
     if ((optind != argc - 2)) {
-        std::cerr << "Invalid ARGV-elements" << std::endl;
+        std::cerr << "Invalid arguments" << std::endl;
         exit(2);
     }
+    return Args{json, posit_width, one_dim_fields, two_dim_fields};
 }
 
 int main(int argc, char *argv[]) {
     if (!(argc >= 5)) {
-        std::cerr << "Usage: " << argv[0]
-                  << "<json> <posit-width> --1d <one-dim field_1>,<one-dim "
-                     "field_2> --2d <two-dim field_1>,<two-dim field_2>\n"
-                     "Converts a JSON file with posits to floating floats \n";
+        print_usage(argv[0]);
         return 2;
     }
-    Input input;
-    parse_data(argc, argv, input);
+    Args input = parse_data(argc, argv);
     json_t transformed = input.json;
 
     for (int i = 0; i < input.one_dim_fields.size(); i++) {

--- a/test_generator/P2FConvertor.cpp
+++ b/test_generator/P2FConvertor.cpp
@@ -1,25 +1,22 @@
+#include "json.hpp"
+#include "universal/include/universal/posit/posit.hpp"
+#include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <string>
-#include <algorithm>
-
-#include "universal/include/universal/posit/posit.hpp"
-#include "json.hpp"
 
 using json_t = nlohmann::json;
 
+template <class T> struct tag { using type = T; };
+template <class Tag> using type = typename Tag::type;
+template <class T, size_t n>
+struct n_dim_vec : tag<std::vector<type<n_dim_vec<T, n - 1>>>> {};
+template <class T> struct n_dim_vec<T, 0> : tag<T> {};
+template <class T, size_t n> using n_dim_vec_t = type<n_dim_vec<T, n>>;
 
-void print_helper() {
-    std::cout << "Usage: P2FConvertor <json> <field> <dimension>\n"
-                 "Converts a JSON file with posits to floating point numbers\n";
-}
-
-json_t parse_data(int argc, char** argv) {
-    if (argc != 4) {
-        print_helper();
-        exit(2);
-    }
-    std::ifstream file(argv[1]);
+json_t parse_data(std::string file_path) {
+    std::ifstream file(file_path);
     json_t j;
     try {
         file >> j;
@@ -30,74 +27,86 @@ json_t parse_data(int argc, char** argv) {
     return j;
 }
 
-template<class T>struct tag{using type=T;};
-template<class Tag>using type=typename Tag::type;
+template <size_t nbits, size_t es>
+void convert_posit_to_float(std::vector<unsigned long> &input,
+                            std::vector<double> &output) {
+    std::transform(input.cbegin(), input.cend(), output.begin(),
+                   [](unsigned long v) -> double {
+                       sw::unum::posit<nbits, es> p;
+                       p.set_raw_bits(v);
+                       return (double)p;
+                   });
+}
 
-template<class T, size_t n>
-    struct n_dim_vec:tag< std::vector< type< n_dim_vec<T, n-1> > > > {};
-  template<class T>
-    struct n_dim_vec<T, 0>:tag<T>{};
-  template<class T, size_t n>
-    using n_dim_vec_t = type<n_dim_vec<T,n>>;
-
-void convert_path_1d(json_t json, std::string field) {
+template <size_t nbits, size_t es>
+void convert_path(json_t json, std::string field, int dim) {
     try {
-        auto data = json["memories"][field].get<n_dim_vec_t<unsigned long, 1>>();
-        std::vector<double> data_float(data.size());
-        std::transform(
-            data.cbegin(),
-            data.cend(),
-            data_float.begin(),
-            [](unsigned long v) -> double {
-                sw::unum::posit <32, 2> p;
-                p.set_raw_bits(v);
-                return (double) p;
-        });
         json_t transformed;
         transformed = json;
-        transformed["memories"][field] = data_float;
+        switch (dim) {
+        case 1: {
+            auto data =
+                json["memories"][field].get<n_dim_vec_t<unsigned long, 1>>();
+            std::vector<double> data_float(data.size());
+            convert_posit_to_float<nbits, es>(data, data_float);
+            transformed["memories"][field] = data_float;
+        } break;
+        case 2: {
+            auto data =
+                json["memories"][field].get<n_dim_vec_t<unsigned long, 2>>();
+            std::vector<std::vector<double>> data_float(
+                data.size(), std::vector<double>(data[0].size(), 0));
+            for (int i = 0; i < data.size(); i++) {
+                convert_posit_to_float<nbits, es>(data[i], data_float[i]);
+            }
+            transformed["memories"][field] = data_float;
+        } break;
+        default:
+            std::cerr << "[Error] The value of the dimension should be 1 or 2"
+                      << std::endl;
+        }
         std::cout << transformed.dump(2);
-    }  catch(nlohmann::json::type_error err) {
-        std::cerr << "[Error] Expected `" << field << ".data' field with type float[]" << std::endl;
+
+    } catch (nlohmann::json::type_error err) {
+        std::cerr << "[Error] Expected `memories." << field
+                  << "` field with type posit[]" << std::endl;
         exit(2);
     }
 }
 
-void convert_path_2d(json_t json, std::string field) {
-    try {
-        auto data = json["memories"][field].get<n_dim_vec_t<unsigned long, 2>>();
-        std::vector<std::vector<double>> data_float(data.size(), std::vector<double>(data[0].size(), 0));
-        for( int i = 0; i < data.size() ; i++) {
-            std::transform(
-                data[i].cbegin(),
-                data[i].cend(),
-                data_float[i].begin(),
-                [](unsigned long v) -> double {
-                    sw::unum::posit <32, 2> p;
-                    p.set_raw_bits(v);
-                    return (double) p;
-            });
-        }
-        json_t transformed;
-        transformed = json;
-        transformed["memories"][field] = data_float;
-        std::cout << transformed.dump(2);
-    }  catch(nlohmann::json::type_error err) {
-        std::cerr << "[Error] Expected `" << field << ".data' field with type float[]" << std::endl;
-        exit(2);
+void convert_to_float(json_t json, std::string field, int posit_width,
+                      int dim) {
+    switch (posit_width) {
+    case 16:
+        convert_path<16, 1>(json, field, dim);
+        break;
+    case 32:
+        convert_path<32, 2>(json, field, dim);
+        break;
+    case 64:
+        convert_path<64, 3>(json, field, dim);
+        break;
+    case 128:
+        convert_path<128, 4>(json, field, dim);
+        break;
+    default:
+        std::cerr << "[Error] The supported posit standards are 16, 32 and 64"
+                  << std::endl;
     }
 }
 
 int main(int argc, char *argv[]) {
-    auto j = parse_data(argc, argv);
-    if(strcmp(argv[3], "1") == 0) {
-        convert_path_1d(j, argv[2]);
+    if (argc != 5) {
+        std::cerr
+            << "Usage: " << argv[0]
+            << "<json> <field> <dimension> <posit-width>\n"
+               "Converts a JSON file with posits to floating point numbers\n";
+        return 2;
     }
-    else if(strcmp(argv[3], "2") == 0) {
-        convert_path_2d(j, argv[2]);
-    }
-    else {
-        print_helper();
-        exit(2);
-    }
+    auto json_file = parse_data(argv[1]);
+    std::string field = argv[2];
+    int dim = std::atoi(argv[3]);
+    int width = std::atoi(argv[4]);
+
+    convert_to_float(json_file, field, width, dim);
 }

--- a/test_generator/P2FConvertor.cpp
+++ b/test_generator/P2FConvertor.cpp
@@ -5,8 +5,18 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <unistd.h>
+#include <getopt.h>
+#include <vector>
 
 using json_t = nlohmann::json;
+
+struct Input {
+    json_t json;
+    int posit_width;
+    std::vector<std::string> one_dim_fields;
+    std::vector<std::string> two_dim_fields;
+};
 
 template <class T> struct tag { using type = T; };
 template <class Tag> using type = typename Tag::type;
@@ -14,18 +24,6 @@ template <class T, size_t n>
 struct n_dim_vec : tag<std::vector<type<n_dim_vec<T, n - 1>>>> {};
 template <class T> struct n_dim_vec<T, 0> : tag<T> {};
 template <class T, size_t n> using n_dim_vec_t = type<n_dim_vec<T, n>>;
-
-json_t parse_data(std::string file_path) {
-    std::ifstream file(file_path);
-    json_t j;
-    try {
-        file >> j;
-    } catch (nlohmann::detail::parse_error err) {
-        std::cerr << err.what() << std::endl;
-        exit(2);
-    }
-    return j;
-}
 
 template <size_t nbits, size_t es>
 void convert_posit_to_float(std::vector<unsigned long> &input,
@@ -39,10 +37,8 @@ void convert_posit_to_float(std::vector<unsigned long> &input,
 }
 
 template <size_t nbits, size_t es>
-void convert_path(json_t json, std::string field, int dim) {
+void convert_path(json_t json, std::string field, int dim, json_t &transformed) {
     try {
-        json_t transformed;
-        transformed = json;
         switch (dim) {
         case 1: {
             auto data =
@@ -65,8 +61,6 @@ void convert_path(json_t json, std::string field, int dim) {
             std::cerr << "[Error] The value of the dimension should be 1 or 2"
                       << std::endl;
         }
-        std::cout << transformed.dump(2);
-
     } catch (nlohmann::json::type_error err) {
         std::cerr << "[Error] Expected `memories." << field
                   << "` field with type posit[]" << std::endl;
@@ -75,38 +69,107 @@ void convert_path(json_t json, std::string field, int dim) {
 }
 
 void convert_to_float(json_t json, std::string field, int posit_width,
-                      int dim) {
+                      int dim, json_t &transformed) {
     switch (posit_width) {
+    case 8:
+        convert_path<8, 1>(json, field, dim, transformed);
+        break;
     case 16:
-        convert_path<16, 1>(json, field, dim);
+        convert_path<16, 1>(json, field, dim, transformed);
         break;
     case 32:
-        convert_path<32, 2>(json, field, dim);
+        convert_path<32, 2>(json, field, dim, transformed);
         break;
     case 64:
-        convert_path<64, 3>(json, field, dim);
+        convert_path<64, 3>(json, field, dim, transformed);
         break;
     case 128:
-        convert_path<128, 4>(json, field, dim);
+        convert_path<128, 4>(json, field, dim, transformed);
         break;
     default:
         std::cerr << "[Error] The supported posit standards are 16, 32 and 64"
                   << std::endl;
+                  exit(2);
+    }
+}
+
+void split_strings(std::string input, char delimiter,
+                   std::vector<std::string> &fields) {
+    std::stringstream stream(input);
+    std::string field;
+
+    while (!stream.eof()) {
+        std::getline(stream, field, delimiter);
+        fields.push_back(field);
+    }
+}
+
+void parse_data(int argc, char **argv, Input &input) {
+    std::ifstream file(argv[1]);
+    try {
+        file >> input.json;
+    } catch (nlohmann::detail::parse_error err) {
+        std::cerr << err.what() << std::endl;
+        exit(2);
+    }
+
+    input.posit_width = std::stoi(argv[2]);
+
+    int c;
+    int index;
+    char *cvalue = NULL;
+    while (1) {
+        static struct option long_options[] = {
+            {"1d", required_argument, 0, 'o'},
+            {"2d", required_argument, 0, 't'},
+            {"help", no_argument, 0, 'h'},
+            {0, 0, 0, 0}};
+        int option_index = 0;
+        c = getopt_long(argc, argv, "o:t:h", long_options, &option_index);
+
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'o':
+            split_strings(optarg, ',', input.one_dim_fields);
+            break;
+        case 't':
+            split_strings(optarg, ',', input.two_dim_fields);
+            break;
+        case '?':
+            std::cerr << "Invalid option" << std::endl;
+            exit(2);
+        default:
+            abort();
+        }
+    }
+    if ((optind != argc - 2)) {
+        std::cerr << "Invalid ARGV-elements" << std::endl;
+        exit(2);
     }
 }
 
 int main(int argc, char *argv[]) {
-    if (argc != 5) {
-        std::cerr
-            << "Usage: " << argv[0]
-            << "<json> <field> <dimension> <posit-width>\n"
-               "Converts a JSON file with posits to floating point numbers\n";
+    if (!(argc >= 5)) {
+        std::cerr << "Usage: " << argv[0]
+                  << "<json> <posit-width> --1d <one-dim field_1>,<one-dim "
+                     "field_2> --2d <two-dim field_1>,<two-dim field_2>\n"
+                     "Converts a JSON file with posits to floating floats \n";
         return 2;
     }
-    auto json_file = parse_data(argv[1]);
-    std::string field = argv[2];
-    int dim = std::atoi(argv[3]);
-    int width = std::atoi(argv[4]);
+    Input input;
+    parse_data(argc, argv, input);
+    json_t transformed = input.json;
 
-    convert_to_float(json_file, field, width, dim);
+    for (int i = 0; i < input.one_dim_fields.size(); i++) {
+        convert_to_float(input.json, input.one_dim_fields[i], input.posit_width,
+                         1, transformed);
+    }
+
+    for (int i = 0; i < input.two_dim_fields.size(); i++) {
+        convert_to_float(input.json, input.two_dim_fields[i], input.posit_width,
+                         2, transformed);
+    }
+    std::cout << transformed.dump(2);
 }


### PR DESCRIPTION
Convertors can take in and convert multiple fields for both 1D and 2D arrays at once.